### PR TITLE
Fix tests with new tracer version

### DIFF
--- a/tests/test-with-dd-trace.js
+++ b/tests/test-with-dd-trace.js
@@ -4,6 +4,11 @@ require('dd-trace/init')
 const testBase = require('node:test')
 const assert = require('node:assert')
 
+// Because the dd-trace-api plugin in dd-trace is not loaded unless the
+// dd-trace-api module is loaded from node_modules, we need to mimic that here.
+const dc = require('diagnostics_channel')
+dc.channel('dd-trace:instrumentation:load').publish({ name: 'dd-trace-api' })
+
 const tracer = require('../index.js')
 
 const test = (name, fn) => {


### PR DESCRIPTION
Newer versions of dd-trace-js don't load the dd-trace-api plugin unless it's loaded from `node_modules`, so the test here is modified to mimic that by publishing to the same channel as our loader hooks.